### PR TITLE
Add hashKeyName option for createPersistedQueryLink

### DIFF
--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -148,6 +148,25 @@ describe('happy path', () => {
     }, done.fail);
   });
 
+  it('supports a custom hash key name', done => {
+    fetch.mockResponseOnce(response);
+    const hashKeyName = 'namedHash';
+    const link = createPersistedQuery({ hashKeyName }).concat(createHttpLink());
+
+    execute(link, { query, variables }).subscribe(result => {
+      expect(result.data).toEqual(data);
+      const [uri, request] = fetch.mock.calls[0];
+      expect(uri).toEqual('/graphql');
+      const parsed = JSON.parse(request.body);
+      expect(parsed.extensions.persistedQuery).toHaveProperty(hashKeyName);
+      expect(parsed.extensions.persistedQuery[hashKeyName]).toBe(
+        query.documentId,
+      );
+
+      done();
+    }, done.fail);
+  });
+
   it('errors if unable to convert to sha256', done => {
     fetch.mockResponseOnce(response);
     const link = createPersistedQuery().concat(createHttpLink());


### PR DESCRIPTION
<!--**Pull Request Labels**


- [ ] has-reproduction
- [x] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->


Hello! Thanks so much for building such a great library!

`apollo-link-persisted-queries` assumes your hash will be sha256, but provides `generateHash` function to override that which we assumed we’d use to pass our query names. However, It seems strange to send a string like `page.v1` as the hash when it is not sha256.

Does that mean I’m using persisted queries in a way they’re not meant to be used or would you accept a PR that allows `createPersistedQueryLink` to take a `hashKeyName` to name that key differently?