### PR TITLE
Replace Map-based cache of query hashes with private property to fix #26.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,23 +10,29 @@
   "typings": "./lib/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/apollographql/apollo-link-persisted-queries.git"
+    "url":
+      "git+https://github.com/apollographql/apollo-link-persisted-queries.git"
   },
   "bugs": {
-    "url": "https://github.com/apollographql/apollo-link-persisted-queries/issues"
+    "url":
+      "https://github.com/apollographql/apollo-link-persisted-queries/issues"
   },
-  "homepage": "https://github.com/apollographql/apollo-link-persisted-queries#readme",
+  "homepage":
+    "https://github.com/apollographql/apollo-link-persisted-queries#readme",
   "scripts": {
-    "build:browser": "browserify ./lib/bundle.umd.js -o=./lib/bundle.js --i apollo-link --i graphql && npm run minify:browser",
+    "build:browser":
+      "browserify ./lib/bundle.umd.js -o=./lib/bundle.js --i apollo-link --i graphql && npm run minify:browser",
     "build": "tsc -p .",
     "bundle": "rollup -c",
     "clean": "rimraf lib/* && rimraf coverage/*",
     "coverage:upload": "codecov",
     "danger": "danger run --verbose",
     "filesize": "npm run build && npm run build:browser && bundlesize",
-    "lint": "prettier --trailing-comma all --single-quote --write \"src/**/*.{j,t}s*\"",
+    "lint":
+      "prettier --trailing-comma all --single-quote --write \"src/**/*.{j,t}s*\"",
     "lint-staged": "lint-staged",
-    "minify:browser": "uglifyjs -c -m -o ./lib/bundle.min.js -- ./lib/bundle.js",
+    "minify:browser":
+      "uglifyjs -c -m -o ./lib/bundle.min.js -- ./lib/bundle.js",
     "postbuild": "npm run bundle",
     "prebuild": "npm run clean",
     "prepublishOnly": "npm run clean && npm run build",
@@ -76,21 +82,14 @@
       ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
     },
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js",
-      "json"
-    ],
-    "setupFiles": [
-      "./scripts/jest.js"
-    ]
+    "moduleFileExtensions": ["ts", "tsx", "js", "json"],
+    "setupFiles": ["./scripts/jest.js"]
   },
   "bundlesize": [
     {
       "name": "apollo-link-persisted-queries",
       "path": "./lib/bundle.min.js",
-      "maxSize": "3.78 kb"
+      "maxSize": "3.9 kb"
     }
   ],
   "lint-staged": {
@@ -102,10 +101,7 @@
       "prettier --trailing-comma all --single-quote --write",
       "git add"
     ],
-    "*.json*": [
-      "prettier --write",
-      "git add"
-    ]
+    "*.json*": ["prettier --write", "git add"]
   },
   "pre-commit": "lint-staged"
 }


### PR DESCRIPTION
Making the cached hash a property of the query object instead of a value in a persistent `Map` should fix #26, since the hash can now be garbage collected whenever the query object is collected, and query objects are no longer kept alive by the `calculated` Map.