### PR TITLE
Fix hash for queries with UTF8 characters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18595,9 +18595,9 @@
       }
     },
     "hash.js": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.5.tgz",
-      "integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
       "requires": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
@@ -21359,12 +21359,6 @@
       "requires": {
         "merge-stream": "^1.0.1"
       }
-    },
-    "js-sha256": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.7.1.tgz",
-      "integrity": "sha512-h8ClGdLqWo3y1PTmcd9aVExTbQouLVLsVigxYSN+rsmlCEX0TlQ0Xkbu4r2OIF+U29e7k1O0NxhtRRd0sJgAjg==",
-      "dev": true
     },
     "js-tokens": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "apollo-link": "^1.2.1",
-    "hash.js": "^1.1.3"
+    "hash.js": "^1.1.7"
   },
   "peerDependencies": {
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
@@ -62,7 +62,6 @@
     "graphql-tag": "^2.5.0",
     "jest": "^23.6.0",
     "jest-fetch-mock": "^1.3.3",
-    "js-sha256": "^0.7.1",
     "lerna": "2.4.0",
     "lint-staged": "4.3.0",
     "lodash": "^4.17.4",
@@ -89,7 +88,7 @@
     {
       "name": "apollo-link-persisted-queries",
       "path": "./lib/bundle.min.js",
-      "maxSize": "3.9 kb"
+      "maxSize": "4.0 kb"
     }
   ],
   "lint-staged": {

--- a/src/__tests__/react.tsx
+++ b/src/__tests__/react.tsx
@@ -6,7 +6,7 @@ import { ApolloClient } from 'apollo-client';
 import gql from 'graphql-tag';
 import { createHttpLink } from 'apollo-link-http';
 import { print, parse } from 'graphql';
-import { sha256 } from 'js-sha256';
+import { createHash } from 'crypto';
 
 import { data, response, shortHash as hash } from './';
 
@@ -35,10 +35,9 @@ const data2 = {
 const response = JSON.stringify({ data });
 const response2 = JSON.stringify({ data: data2 });
 const queryString = print(query);
-const hash = sha256
-  .create()
+const hash = createHash('sha256')
   .update(queryString)
-  .hex();
+  .digest('hex');
 
 import { createPersistedQueryLink as createPersistedQuery, VERSION } from '../';
 


### PR DESCRIPTION
This PR upgrades `hash.js` following the merge of https://github.com/indutny/hash.js/pull/22. This fixes persistent queries for queries containing non-ASCII characters. Otherwise, the following error could be thrown on the server: [`provided sha does not match query`](https://github.com/apollographql/apollo-server/blob/8b918e5bb6dcd24d33bd8cc664c663aa6917f691/packages/apollo-server-core/src/requestPipeline.ts#L132).

A new test should help us prevent the same bug in future.

----
**Original PR description (outdated):**

There is an [upstream bug in `hash.js`](https://github.com/indutny/hash.js/issues/20), which causes a mismatch between the hash produced on the client and the server. As a result, I see [`provided sha does not match query`](https://github.com/apollographql/apollo-server/blob/8b918e5bb6dcd24d33bd8cc664c663aa6917f691/packages/apollo-server-core/src/requestPipeline.ts#L132) every time a non-ASCII character is included into a query. An example of that can be a hard-coded argument value:

```graphql
query Test($id: ID!) {
    foo(id: $id, cyrillicChars: "привет", chineseChars: "您好") {
      bar
    }
  }
```

This PR replaces `hash.js` with [`js-sha256`](https://www.npmjs.com/package/js-sha256), which seems to cope well with UTF8 characters in queries. There is also a new test that makes sure that whatever client-side hashing algorithm is chosen in future, its output always matches the output of `crypto`, which is used by Apollo Server.

⚠️ I had to increase max bundle size by 1.5KB in `package.json` after switching to `js-sha256`. I'm not bound to this new library, so am happy to replace it with whatever else we can find. Simply fixing https://github.com/indutny/hash.js/issues/20 would be ideal, but it's not something I can lift.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [ ] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->