### PR TITLE
Elaborate on hash and error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The query signature for Automatic Persisted Queries is sent along the extensions
 }
 ```
 
-When sending an Automatic Persisted Query, the client ommits the `query` field normally present, and instead sends an extension field with a `persistedQuery` object as shown above. The hash algorithm defaults to a `sha256` hash of the query string.
+When sending an Automatic Persisted Query, the client omits the `query` field normally present, and instead sends an extension field with a `persistedQuery` object as shown above. The hash must be a `sha256` hash of the query string.
 
 If the client needs to register the hash, the query signature will be the same but include the full query text like so:
 
@@ -102,7 +102,7 @@ If the client needs to register the hash, the query signature will be the same b
 This should only happen once across all clients when a new query is introduced into your application.
 
 **Error Responses**
-When the initial query signature is received by a backend, if it is unable to find the hash previously stored, it must send back the following response signature:
+When the initial query signature is received by a backend, if it is unable to find the hash previously stored, it must send back the following response signature with a 200 OK status code:
 
 ```js
 {


### PR DESCRIPTION
Some updates based on my experience with implementing this on the client-side.

- The hash **must** be an SHA256 hash. Some implementations just treat the hash as an opaque identifier, but Apollo Server actually validates that it's the right SHA256 hash. This spec should err on the side of being too explicit rather than not explicit enough. It would be good to use a faster non-cryptographic hash (like xxHash), but for now this needs to use SHA256.
- The `PersistedQueryNotFound` error is returned with a HTTP 200 status code. Closes #35 